### PR TITLE
Improved resumable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var request = require('request');
 var resumable = require('resumable-request');
 
 resumable(request, { url: "http://example.org/" })
-.pipe(fs.createWriteStream('out.txt'));
+  .pipe(fs.createWriteStream('out.txt'));
 ```
 
 ## Documentation
@@ -52,7 +52,7 @@ var baseResumable = resumable.defaults({
 // You may override defaults inline with the request. The following will
 // report progress every 500ms, instead of 2000ms that was specified above.
 baseResumable(request, { url: "http://example.org/" }, { progressInterval: 500 })
-.pipe(fs.createWriteStream('out.txt'));
+  .pipe(fs.createWriteStream('out.txt'));
 ```
 
 ### `progress` Event
@@ -73,10 +73,10 @@ For example:
 
 ```js
 resumable(request, { url: "http://example.org/" }, { progressInterval: 2000 })
-.on('progress', function onProgress(state) {
-  console.log(state);
-})
-.pipe(fs.createWriteStream('out.txt'));
+  .on('progress', function onProgress(state) {
+    console.log(state);
+  })
+  .pipe(fs.createWriteStream('out.txt'));
 ```
 
 ## Why does resumable need "request" module as an argument?

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # resumable-request
 Resumable requests with node.js
 
-It allows you to continue long streaming requests even if they get interrupted by network errors. In order for requests to be resumable, the server __must__ respond with Content-length header and support [HTTP Range request header](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#range-request-header).
+It allows you to continue long streaming requests even if they get interrupted by network errors. In order for requests to be resumable, the server __must__ respond with `Content-Length` and `Accept-Ranges: bytes` headers and support [Range requests](https://en.wikipedia.org/wiki/Byte_serving).
 
 This is ideal for setups with flaky network issuing requests with large output that needs to be downloaded and processed as a stream.
 
@@ -15,9 +15,9 @@ $ npm install --save resumable-request
 
 ## Usage
 
-```
-request = require('request');
-resumable = require('resumable-request');
+```js
+var request = require('request');
+var resumable = require('resumable-request');
 
 resumable(request, { url: "http://example.org/" })
 .pipe(fs.createWriteStream('out.txt'));
@@ -25,7 +25,7 @@ resumable(request, { url: "http://example.org/" })
 
 ## Documentation
 
-### resumable(request, requestOpts, resumableOpts = { maxRetries = 10 })
+### resumable(request, requestOpts, resumableOpts)
 
 Initiate a resumable request. Each request is executed using the __request__ module, passing __requestOpts__.
 
@@ -33,6 +33,51 @@ For requestOpts refer to the options in the documentation of [request](https://g
 
 __resumableOpts__ is an optional object describing the options handled by resumable itself:
  * __maxRetries__: Maximum times to retry a request. (default: 10)
+ * __retryInterval__: The time to wait before retrying a failed request, in milliseconds. (default: 1000)
+ * __progressInterval__: The interval between reporting progress with `progress` events, in milliseconds. (default: 1000)
+
+### resumable.defaults(resumableOpts)
+
+Returns a wrapper around the normal resumable API that defaults to whatever options you pass to it.
+
+For example:
+
+```js
+var baseResumable = resumable.defaults({
+  maxRetries: 5,
+  retryInterval: 100,
+  progressInterval: 2000
+})
+
+// You may override defaults inline with the request. The following will
+// report progress every 500ms, instead of 2000ms that was specified above.
+baseResumable(request, { url: "http://example.org/" }, { progressInterval: 500 })
+.pipe(fs.createWriteStream('out.txt'));
+```
+
+### `progress` Event
+
+You can follow the download progress by registering a function for the `progress` event on the resumable request instance. The function will be called with a single argument in an interval (as specified by the `progressInterval` resumable request option), that has the following form:
+
+```js
+{
+  percentage: 50,          // Overall progress as an integer in the range [0, 100]
+  size: {
+    transferred: 27610959  // The transferred response body size in bytes
+    total: 90044871,       // The total response body size in bytes
+  }
+}
+```
+
+For example:
+
+```js
+resumable(request, { url: "http://example.org/" }, { progressInterval: 2000 })
+.on('progress', function onProgress(state) {
+  console.log(state);
+})
+.pipe(fs.createWriteStream('out.txt'));
+```
 
 ## Why does resumable need "request" module as an argument?
 

--- a/index.coffee
+++ b/index.coffee
@@ -41,7 +41,7 @@ class ResumableRequest extends stream.Readable
 			# We do not support that -- resumable request can only be used
 			# to *download* a resource, i.e. only the response is resumable.
 			# piping will fail with a not-so-obvious error as soon as the stream
-			# gets going because we don't implement Writable, so it's detect this
+			# gets going because we don't implement Writable, so detect this
 			# and emit a more appropriate error.
 			@error = new Error('ResumableRequest is not writable')
 			# have to abort asynchronously to allow client code to register 'error' handlers
@@ -134,6 +134,10 @@ class ResumableRequest extends stream.Readable
 
 	_follow: (response) ->
 		if not @response?
+			# Create a response "proxy" for the first response by wrapping it in a
+			# custom PassThrough stream, copying interesting attributes such as
+			# statusCode, headers, etc. This is needed because we only emit one
+			# 'response' event where client code can attach listeners on.
 			@bytesTotal ?= parseInt(response.headers['content-length'])
 			@_reportProgress()
 			@_reportProgress.flush()

--- a/index.coffee
+++ b/index.coffee
@@ -32,8 +32,8 @@ class ResumableRequest extends stream.Readable
 		@retries = 0
 		@maxRetries = opts.maxRetries ? 10
 
-		@_retry = throttle(@_retry.bind(this), opts.retryInterval ? 1000)
-		@_reportProgress = throttle(@_reportProgress.bind(this), opts.progressInterval ? 1000)
+		@_retry = throttle(@_retry.bind(this), opts.retryInterval ? 1000, leading: false)
+		@_reportProgress = throttle(@_reportProgress.bind(this), opts.progressInterval ? 1000, leading: false)
 
 		@on 'pipe', =>
 			# request can be written to when uploading a resource to a URL.

--- a/index.coffee
+++ b/index.coffee
@@ -32,7 +32,8 @@ class ResumableRequest extends stream.Readable
 		@retries = 0
 		@maxRetries = opts.maxRetries ? 10
 
-		@_retry = throttle(@_retry.bind(this), opts.retryInterval ? 1000, leading: false)
+		retryNow = @_retry.bind(this)
+		@_retry = throttle(retryNow, opts.retryInterval ? 1000, leading: false)
 		@_reportProgress = throttle(@_reportProgress.bind(this), opts.progressInterval ? 1000, leading: false)
 
 		@on 'pipe', =>
@@ -44,8 +45,7 @@ class ResumableRequest extends stream.Readable
 			# and emit a more appropriate error.
 			@error = new Error('ResumableRequest is not writable')
 			# have to abort asynchronously to allow client code to register 'error' handlers
-			process.nextTick =>
-				@_retry()
+			process.nextTick(retryNow)
 
 		@_request()
 

--- a/index.coffee
+++ b/index.coffee
@@ -1,60 +1,170 @@
-through = require 'through'
+stream = require 'readable-stream'
 
 module.exports = (requestModule, requestOpts, opts) ->
-	res = new Resumable(requestModule, requestOpts, opts)
-	return res.resume()
+	return new ResumableRequest(requestModule, requestOpts, opts)
 
-class Resumable
-	constructor: (requestModule, requestOpts, opts) ->
-		@stream = through (data) =>
-			@bytesRead += data.length
-			@stream.emit('data', data)
-		@bytesRead = 0
-		@retries = 0
-		@maxRetries = opts?.maxRetries ? 10
-		@contentLength = null
-		@requestOpts = requestOpts
-		@requestModule = requestModule
+module.exports.defaults = (defaults = {}) ->
+	(requestModule, requestOpts, opts) ->
+		opts = Object.assign {}, defaults, opts
+		return new ResumableRequest(requestModule, requestOpts, opts)
+
+cloneResponse = (response) ->
+	# creates an `http.IncomingMessage`-like stream, that can also be piped to.
+	s = new stream.PassThrough()
+	[ 'headers', 'httpVersion', 'method', 'rawHeaders', 'statusCode', 'statusMessage' ].forEach (prop) ->
+		s[prop] = response[prop]
+	return s
+
+throttle = (fn, interval) ->
+	timeoutId = null
+	cancel = ->
+		return if not timeoutId?
+		timeoutId = clearTimeout(timeoutId)
+	apply = ->
+		cancel()
+		fn()
+	throttledFn = ->
+		return if timeoutId?
+		timeoutId = setTimeout(apply, interval)
+	throttledFn.apply = apply
+	throttledFn.cancel = cancel
+	return throttledFn
+
+wrapLegacyStream = (s) ->
+	new stream.Readable().wrap(s)
+
+class ResumableRequest extends stream.Readable
+	constructor: (@requestModule, @requestOpts, opts = {}) ->
+		super()
+
 		@error = null
+		@request = null
+		@response = null
+
+		@bytesRead = 0
+		@bytesTotal = null
+		@retries = 0
+		@maxRetries = opts.maxRetries ? 10
+
+		@_retry = throttle(@_retry.bind(this), opts.retryInterval ? 1000)
+		@_reportProgress = throttle(@_reportProgress.bind(this), opts.progressInterval ? 1000)
+
+		@on 'pipe', ->
+			# request can be written to when uploading a resource to a URL.
+			# We do not support that -- resumable request can only be used
+			# to *download* a resource, i.e. only the response is resumable.
+			# piping will fail as soon as the stream gets going because we don't
+			# implement Writable but it's better to fail early.
+			throw new Error('ResumableRequest is not writable.')
+
+		@_request()
+
+	abort: ->
+		@emit('abort')
+		@_end()
+
+	push: (data, encoding) ->
+		@retries = 0 # we got some data, reset number of retries
+		@bytesRead += data.length if data?
+		@_reportProgress()
+		return super(data, encoding)
+
+	_end: ->
+		return if @ended
+		@ended = true
+		doEnd = =>
+			@request.abort()
+			@_retry.cancel()
+			@_reportProgress.cancel()
+			@_reportProgress.apply()
+			@emit('end')
+			if not @error?
+				@emit('complete')
+		if @response?
+			@response.end(doEnd)
+		else
+			doEnd()
+
+	_read: -> # noop -- we're manually pushing buffers into self
+
+	progress: ->
+		retries: @retries
+		maxRetries: @maxRetries
+		percentage: Math.round(100 * @bytesRead / @bytesTotal) or 0
+		size: { transferred: @bytesRead, total: @bytesTotal }
+
+	_reportProgress: (progress = {}) =>
+		@emit('progress', Object.assign @progress(), progress)
 
 	# Sends the requests and sets up listeners in order
 	# to be able to resume.
 	# Returns a stream object similar to the result of `request`.
 	# 'response' and 'request' events on the stream are generated
 	# based on the first request, in order to emit them only once.
-	resume: ->
-		@requestOpts.headers ?= {}
-		@requestOpts.headers.range = "bytes=#{@bytesRead}-"
-		@requestModule(@requestOpts)
-		.on 'request', (reqObj) =>
-			if @retries is 0
-				@stream.emit('request', reqObj)
-		.on 'response', (response) =>
+	_request: ->
+		if @response?
+			# the first response is emitted to listeners, so only specify the
+			# Range header on subsequent requests, to avoid causing a 206 response
+			# status code, which may be unexpected.
+			@requestOpts.headers ?= {}
+			@requestOpts.headers.range = "bytes=#{@bytesRead}-"
+
+		initial = @request is null
+		aborted = false
+		errored = false
+
+		@request = @requestModule(@requestOpts)
+		.once 'request', (reqObj) =>
+			if initial
+				@emit('request', reqObj)
+		.once 'response', (response) =>
+			@_follow(response)
 			if response.statusCode >= 400
 				@error = new Error("Request failed with status code #{response.statusCode}")
-				@stream.emit('error', @error)
-			else if @retries is 0
-				@stream.emit('response', response)
-				@contentLength = parseInt(response.headers['content-length'])
+				@_retry() # will abort the request
 		.on 'error', (err) =>
-			@stream.emit('socketError', err)
-			@retryOrEnd()
-		.on('end', => @retryOrEnd())
-		.pipe(@stream, end: false)
+			errored = true
+			@emit('socketError', err)
+			if aborted
+				@_retry()
+		.once 'abort', ->
+			aborted = true
+		.once 'complete', =>
+			if errored or (@bytesTotal? and @bytesRead < @bytesTotal)
+				@_retry()
+			else
+				@_end() # received complete response
+
+	_follow: (response) ->
+		if not @response?
+			@bytesTotal ?= parseInt(response.headers['content-length'])
+			@response = cloneResponse(response).on('data', @push.bind(this))
+			@emit('response', @response)
+
+		# wrapping the stream in a v3 Readable stream streamlines the emission
+		# of some events and avoids some weird edge-cases
+		wrapLegacyStream(response).pipe(@response, end: false)
 
 	# Decide whether to resume downloading based on number
 	# of bytes downloaded and maximum retries.
-	retryOrEnd: ->
-		if @error?
-			return # we have emitted unrecoverable error (eg bad status code)
-		else if not @contentLength?
-			@stream.error('error', new Error('Cannot resume without Content-length response header'))
-		else if @bytesRead == @contentLength
-			@stream.end()
-		else if @bytesRead > @contentLength
-			@stream.emit('error', new Error('Resumable received more bytes than expected'))
-		else if @retries >= @maxRetries
-			@stream.emit('error', new Error('Maximum retries exceeded.'))
-		else
-			@retries += 1
-			@resume()
+	_retry: ->
+		try
+			if @error?
+				throw @error # we have already emitted an unrecoverable error
+			if @response? and not @bytesTotal
+				throw new Error('Cannot resume without Content-Length response header')
+			if @response? and @response.headers['accept-ranges']?.toLowerCase() != 'bytes'
+				throw new Error('Server does not support Byte Serving')
+			if @bytesTotal and @bytesRead > @bytesTotal
+				throw new Error('Received more bytes than expected!')
+			if @retries >= @maxRetries
+				throw new Error('Maximum retries exceeded')
+		catch err
+			@error = err
+			@emit('error', err)
+			@abort()
+			return
+
+		@retries += 1
+		@emit('retry', @progress())
+		@_request()

--- a/index.coffee
+++ b/index.coffee
@@ -1,12 +1,17 @@
 stream = require 'readable-stream'
 throttle = require 'lodash.throttle'
 
+# use the same module as request.js, to preserve behaviour.
+# Object.assign() doesn't fit, because it copies `undefined`
+# props as well, whereas we'd rather not.
+extend = require 'extend'
+
 module.exports = (requestModule, requestOpts, opts) ->
 	return new ResumableRequest(requestModule, requestOpts, opts)
 
 module.exports.defaults = (defaults = {}) ->
 	(requestModule, requestOpts, opts) ->
-		opts = Object.assign {}, defaults, opts
+		opts = extend {}, defaults, opts
 		return new ResumableRequest(requestModule, requestOpts, opts)
 
 cloneResponse = (response) ->

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepublish": "./node_modules/.bin/coffee -c index.coffee"
   },
   "dependencies": {
+    "lodash.throttle": "^4.1.1",
     "readable-stream": "^2.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepublish": "./node_modules/.bin/coffee -c index.coffee"
   },
   "dependencies": {
-    "through": "~2.3.8"
+    "readable-stream": "^2.3.3"
   },
   "devDependencies": {
     "chai": "~3.5.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepublish": "./node_modules/.bin/coffee -c index.coffee"
   },
   "dependencies": {
+    "extend": "^3.0.1",
     "lodash.throttle": "^4.1.1",
     "readable-stream": "^2.3.3"
   },

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -80,13 +80,6 @@ describe 'resumable', ->
 		.on 'close', ->
 			done()
 
-	it 'should fail if treated as writable stream', (done) ->
-		f = ->
-			fs.createReadStream(TEST_FILE)
-			.pipe(resumable(request, { url: "http://localhost:#{TEST_PORT}/" }))
-		expect(f).to.throw(Error)
-		done()
-
 	expectError = (str, done, fn) ->
 		error = null
 		fn()
@@ -95,6 +88,11 @@ describe 'resumable', ->
 		.on 'end', ->
 			expect(error.toString()).to.contain(str)
 			done()
+
+	it 'should fail if treated as writable stream', (done) ->
+		expectError 'ResumableRequest is not writable', done, ->
+			fs.createReadStream(TEST_FILE)
+			.pipe(resumable(request, { url: "http://localhost:#{TEST_PORT}/" }))
 
 	it 'should fail if maxRetries are exceeded', (done) ->
 		expectError 'Maximum retries exceeded', done, ->

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -1,16 +1,19 @@
 http = require 'http'
 fs = require 'fs'
-progress = require 'request-progress'
 Range = require('http-range').Range
-resumable = require '../'
 { expect } = require 'chai'
-request = require 'request'
 url = require 'url'
+stream = require 'readable-stream'
+
+# we're emulating a flaky connection by simply not sending data from the test
+# server down the socket. no need to wait for ages, so specify tiny timeouts.
+request = require('request').defaults(timeout: 100)
+resumable = require('../').defaults(retryInterval: 100, maxRetries: 2)
 
 TEST_PORT = process.env.TEST_PORT ? 5000
 TEST_FILE = './test/test.html'
 TEST_FILE_LENGTH = 128086
-TEST_BROKEN_RESPONSE_SIZE = 20000
+TEST_BROKEN_RESPONSE_SIZE = 40000
 
 # returns only TEST_BROKEN_RESPONSE_SIZE bytes per request
 # to test resumable downloads
@@ -26,11 +29,18 @@ brokenServer = http.createServer (req, res) ->
 		opts.start = 0
 		opts.end = TEST_BROKEN_RESPONSE_SIZE - 1
 	qs = url.parse(req.url, true).query
+	if qs.hang?
+		return # hang forever; will cause socket timeout
 	if not qs.noContentLength?
 		res.setHeader('Content-length', TEST_FILE_LENGTH - opts.start)
+	if not qs.noByteServing?
+		res.setHeader('Accept-Ranges', 'Bytes')
 	if qs.failAt? and opts.start >= qs.failAt <= opts.end
 		res.statusCode = 404
-	fs.createReadStream(TEST_FILE, opts).pipe(res)
+	fs.createReadStream(TEST_FILE, opts).on 'data', (data) ->
+		if not data?
+			return # hang forever; will cause socket timeout
+		res.write data
 
 describe 'resumable', ->
 	before ->
@@ -53,26 +63,54 @@ describe 'resumable', ->
 			expect(Buffer.concat(chunks)).to.eql(fs.readFileSync(TEST_FILE))
 			done()
 
-	it 'should fail if maxRetries are exceeded', (done) ->
-		resumable(request, { url: "http://localhost:#{TEST_PORT}/" }, { maxRetries: 2 })
-		.on 'error', ->
-			done()
+	it 'should stream the inner response', (done) ->
+		chunks = []
+		resumable(request, { url: "http://localhost:#{TEST_PORT}/" })
+		.on 'response', (response) ->
+			response
+			.on 'data', (data) ->
+				chunks.push(data)
 		.on 'end', ->
-			done(new Error('end should not have been called'))
+			expect(Buffer.concat(chunks)).to.eql(fs.readFileSync(TEST_FILE))
+			done()
+
+	it 'should pipe the whole response', (done) ->
+		resumable(request, { url: "http://localhost:#{TEST_PORT}/" })
+		.pipe(fs.createWriteStream('/dev/null'))
+		.on 'close', ->
+			done()
+
+	it 'should fail if treated as writable stream', (done) ->
+		f = ->
+			fs.createReadStream(TEST_FILE)
+			.pipe(resumable(request, { url: "http://localhost:#{TEST_PORT}/" }))
+		expect(f).to.throw(Error)
+		done()
+
+	expectError = (str, done, fn) ->
+		error = null
+		fn()
+		.on 'error', (e) ->
+			error = e
+		.on 'end', ->
+			expect(error.toString()).to.contain(str)
+			done()
+
+	it 'should fail if maxRetries are exceeded', (done) ->
+		expectError 'Maximum retries exceeded', done, ->
+			resumable(request, { url: "http://localhost:#{TEST_PORT}/?hang=1" })
 
 	it 'should fail if no content-length is emitted', (done) ->
-		resumable(request, { url: "http://localhost:#{TEST_PORT}/?noContentLength=1" })
-		.on 'error', ->
-			done()
-		.on 'end', ->
-			done(new Error('end should not have been called'))
+		expectError 'Cannot resume without Content-Length response header', done, ->
+			resumable(request, { url: "http://localhost:#{TEST_PORT}/?noContentLength=1" })
+
+	it 'should fail if no accept-ranges is emitted', (done) ->
+		expectError 'Server does not support Byte Serving', done, ->
+			resumable(request, { url: "http://localhost:#{TEST_PORT}/?noByteServing=1" })
 
 	it 'should fail if some of the resumed requests return status code >= 400', (done) ->
-		resumable(request, { url: "http://localhost:#{TEST_PORT}/?failAt=#{TEST_FILE_LENGTH / 2}" })
-		.on 'error', ->
-			done()
-		.on 'end', ->
-			done(new Error('end should not have been called'))
+		expectError 'Request failed with status code 404', done, ->
+			resumable(request, { url: "http://localhost:#{TEST_PORT}/?failAt=#{TEST_FILE_LENGTH / 2}" })
 
 	it 'should emit one "request" event', (done) ->
 		requestEvents = []
@@ -95,21 +133,20 @@ describe 'resumable', ->
 			done(e)
 		.on 'end', ->
 			expect(responseEvents.length).to.equal(1)
-			expect(responseEvents).to.have.property(0).that.is.an.instanceof(http.IncomingMessage)
+			expect(responseEvents).to.have.property(0).that.is.an.instanceof(stream.Readable)
+			[ 'headers', 'httpVersion', 'method', 'rawHeaders', 'statusCode', 'statusMessage' ].forEach (prop) ->
+				expect(responseEvents[0]).to.have.property(prop)
 			done()
 
-	it 'should be compatible with request-progress', (done) ->
+	it 'should report progress', (done) ->
 		progressEvents = []
-		progress resumable(request, { url: "http://localhost:#{TEST_PORT}/" }), { throttle: 0 }
+		resumable(request, { url: "http://localhost:#{TEST_PORT}/" }, { progressInterval: 10 })
 		.on 'progress', (prog) ->
-			# "cheap" deep copy
-			# otherwise all progress events are the same
-			copyProg = JSON.parse(JSON.stringify(prog))
-			progressEvents.push(copyProg)
+			progressEvents.push(prog)
 		.on 'end', ->
 			expect(progressEvents.length).to.be.greaterThan(0)
 			expect(progressEvents[0]).to.have.property('percentage').greaterThan(0)
-			expect(progressEvents[progressEvents.length - 1]).to.have.property('percentage').that.equals(1)
+			expect(progressEvents[progressEvents.length - 1]).to.have.property('percentage').that.equals(100)
 			expect(progressEvents[progressEvents.length - 1]).to.have.deep.property('size.total').that.equals(TEST_FILE_LENGTH)
 			expect(progressEvents[progressEvents.length - 1]).to.have.deep.property('size.transferred').that.equals(TEST_FILE_LENGTH)
 			done()

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -145,7 +145,7 @@ describe 'resumable', ->
 			progressEvents.push(prog)
 		.on 'end', ->
 			expect(progressEvents.length).to.be.greaterThan(0)
-			expect(progressEvents[0]).to.have.property('percentage').greaterThan(0)
+			expect(progressEvents[0]).to.have.property('percentage').that.equals(0)
 			expect(progressEvents[progressEvents.length - 1]).to.have.property('percentage').that.equals(100)
 			expect(progressEvents[progressEvents.length - 1]).to.have.deep.property('size.total').that.equals(TEST_FILE_LENGTH)
 			expect(progressEvents[progressEvents.length - 1]).to.have.deep.property('size.transferred').that.equals(TEST_FILE_LENGTH)


### PR DESCRIPTION
This makes the following fixes and improvements:

- Consumers now will properly receive data even if subscribing to the response instead of the returned stream
- Resume now works even if the initial request fails
- Resumable is now itself a Readable stream and consumers work with it instead of a proxy transform stream
- Added a way to produce a factory with default options applied to every subsequent use
- Now only tries to resume if the server makes known it support range requests via an Accept-Ranges header
- Now raises an exception as soon as client code tries to pipe into the resumable instance
- Now resets the retry count as soon as bytes manage to get through
- Added ability to report progress via a new ‘progress’ event sent in a customisable interval
- Now makes sure it doesn’t cause the server to respond with status 206
- An ‘end’ event is now always emitted
- Streamlined the internal API a bit, by renaming methods
- Improved the test server to cause actual socket errors for somewhat more realistic testing
- Added a couple more tests and improved some others

I pulled out some hair with this :)

Including you, Jonas, as a reviewer for your experience with node streams in case you can spot issues with the way the stream subclass is implemented.