### PR TITLE
Refactor the way the response is forwarded

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -57,7 +57,7 @@ class ResumableRequest extends stream.Readable
 		@emit('abort')
 		@destroy(@error)
 
-	push: (data, encoding) ->
+	push: (data, encoding) =>
 		@retries = 0 # we got some data, reset number of retries
 		@bytesRead += data.length if data?
 		@_reportProgress()
@@ -150,10 +150,10 @@ class ResumableRequest extends stream.Readable
 			@response = cloneResponse(response)
 			@destinations.forEach ([ dest, opts ]) =>
 				@response.pipe(dest, opts)
-			delete @destinations
+			@destinations = []
 			@emit('response', @response)
 
-		onData = @push.bind(this)
+		onData = @push
 		onEnd = ->
 			response.removeListener('data', onData)
 			response.removeListener('error', onEnd)

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "url": "https://github.com/resin-io-modules/resumable-request"
   },
   "scripts": {
-    "pretest": "./node_modules/.bin/resin-lint index.coffee test/",
-    "test": "./node_modules/.bin/mocha --compilers coffee:coffee-script/register",
-    "prepublish": "./node_modules/.bin/coffee -c index.coffee"
+    "pretest": "resin-lint index.coffee test/",
+    "test": "mocha --no-exit --compilers coffee:coffee-script/register",
+    "prepublish": "coffee -c index.coffee"
   },
   "dependencies": {
     "extend": "^3.0.1",

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -29,7 +29,7 @@ brokenServer = http.createServer (req, res) ->
 		opts.start = 0
 		opts.end = TEST_BROKEN_RESPONSE_SIZE - 1
 	qs = url.parse(req.url, true).query
-	if qs.hang?
+	if qs.hang? and req.headers.range?
 		return # hang forever; will cause socket timeout
 	if not qs.noContentLength?
 		res.setHeader('Content-length', TEST_FILE_LENGTH - opts.start)
@@ -38,8 +38,6 @@ brokenServer = http.createServer (req, res) ->
 	if qs.failAt? and opts.start >= qs.failAt <= opts.end
 		res.statusCode = 404
 	fs.createReadStream(TEST_FILE, opts).on 'data', (data) ->
-		if not data?
-			return # hang forever; will cause socket timeout
 		res.write data
 
 describe 'resumable', ->


### PR DESCRIPTION
Before this change, the response would not be gracefully termnated if there was something on the reader side prevented the flow of the stream.

This also fixes an issue where the whole response would accidentally be buffered inside `ResumableRequest` unless it was consumed as well.